### PR TITLE
Add support for Allegro CL Modern Mode

### DIFF
--- a/src/route.lisp
+++ b/src/route.lisp
@@ -9,6 +9,20 @@
 (in-package #:routes)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; macros
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmacro intern-keyword (name)
+  `(intern (
+	    #+allegro
+	    ,(ecase excl:*current-case-mode*
+	       (:case-sensitive-lower 'string-downcase)
+	       (:case-insensitive-upper 'string-upcase))
+	    #-allegro
+	    ,'string-upcase
+	    ,name) :keyword))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; interface
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -38,7 +52,7 @@
 
 (defun parse-path (str &optional varspecs)
   (flet ((mkvar (name &optional wildcard)
-           (let* ((spec (intern (string-upcase name) :keyword))
+           (let* ((spec (intern-keyword name))
                   (parse-fun (getf varspecs spec )))
              (if parse-fun
                  (make-instance (if wildcard
@@ -53,7 +67,7 @@
     (if (> (length str) 0)
         (if (char= (char str 0)
                    #\*)
-            (list (mkvar (intern (string-upcase (subseq str 1)) :keyword) t))
+            (list (mkvar (intern-keyword (subseq str 1)) t))
             (let ((pos (position #\: str)))
               (if pos
                   (let ((rest (if (char= (elt str (1+ pos)) #\()


### PR DESCRIPTION
This pull request add support for Allegro CL Modern Mode
(see http://franz.com/support/documentation/current/doc/case.htm)

This is implemented as a macro that expand as the same code as the current version for others Lisp than ACL.

This patch will be useful to other users that would want to use RESTAS with ACL.

(routes.test:run-routes-tests) return 35 successful tests on
- Allegro CL 10 Modern and ANSI modes
- SBCL 1.3.5